### PR TITLE
change build script name to from prepublish to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "NODE_ENV=production webpack -p --config webpack.production.config.js",
     "test": "babel-node testrunner",
     "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples",
-    "prepublish": "babel ./src/ -d ./lib/"
+    "prepare": "babel ./src/ -d ./lib/"
   },
   "author": "Christian Alfoni",
   "license": "MIT",


### PR DESCRIPTION
Not sure how compiled files were appearing in the /lib folder before upon installation.
NPM does not run prepublish scripts for packages installed from git urls, so I changed `prepublish` to `prepare`.